### PR TITLE
chore: add deps installation in setup script for macos and linux

### DIFF
--- a/scripts/setup-agent.sh
+++ b/scripts/setup-agent.sh
@@ -207,10 +207,18 @@ info_message "Starting setup. Using temporary directory: \"$TMP_FOLDER\""
 
 # Step -1: Download all core scripts
 info_message "Downloading core component scripts..."
+curl -SL -s "https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent/main/scripts/deps.sh" > "$TMP_FOLDER/install-deps.sh"
 curl -SL -s "https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent/main/scripts/install.sh" > "$TMP_FOLDER/install-wazuh-agent.sh"
 curl -SL -s "https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-cert-oauth2/refs/tags/v$WOPS_VERSION/scripts/install.sh" > "$TMP_FOLDER/install-wazuh-cert-oauth2.sh"
 curl -SL -s "https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent-status/refs/tags/v$WAZUH_AGENT_STATUS_VERSION/scripts/install.sh" > "$TMP_FOLDER/install-wazuh-agent-status.sh"
 curl -SL -s "https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-yara/refs/tags/v$WAZUH_YARA_VERSION/scripts/install.sh" > "$TMP_FOLDER/install-yara.sh"
+
+# Step 0: Install dependencies
+info_message "Installing dependencies"
+if ! (bash "$TMP_FOLDER/install-deps.sh") 2>&1; then
+    error_message "Failed to install dependencies"
+    exit 1
+fi
 
 # Step 1: Download and install Wazuh agent
 info_message "Installing Wazuh agent"


### PR DESCRIPTION
### Key Changes
- Improve `deps.sh` script by:
    - using brew to install dependencies, even in root mode
    - add step to update installed `bash` on macos, needed for yara's active response process 
- Use `deps.sh` script in wazuh agent setup for macos and linux

### Why
To control the dependencies needed for the setup to work

### Tested On
Ubuntu and macOS – works in root mode on macos.
