### PR TITLE
feat: add USB DLP Active Response scripts

### DIFF
--- a/files/active-response/README.md
+++ b/files/active-response/README.md
@@ -1,0 +1,68 @@
+# USB DLP Active Response Scripts
+
+These scripts are automatically deployed to Wazuh agents by the `setup-agent.sh` (Linux/macOS) and `setup-agent.ps1` (Windows) installation scripts.
+
+## Scripts
+
+| Script | Platform | Purpose |
+|--------|----------|---------|
+| `disable-usb-storage.ps1` | Windows | Blocks USB mass storage devices via registry |
+| `disable-usb-storage.sh` | Linux | Blocks USB storage via kernel module and udev rules |
+| `disable-usb-storage-macos.sh` | macOS | Ejects USB storage devices via diskutil |
+| `alert-usb-hid.ps1` | Windows | Collects USB HID device forensic evidence |
+| `alert-usb-hid.sh` | Linux/macOS | Collects USB HID device forensic evidence |
+
+## Installation Locations
+
+After agent setup completes, scripts are installed to:
+
+| Platform | Directory |
+|----------|-----------|
+| Windows | `C:\Program Files (x86)\ossec-agent\active-response\bin\` |
+| Linux | `/var/ossec/active-response/bin/` |
+| macOS | `/Library/Ossec/active-response/bin/` |
+
+## Triggered By
+
+These scripts are triggered by Wazuh Manager Active Response rules when USB devices are detected:
+
+**USB Mass Storage (Data Exfiltration Prevention):**
+- Windows: Rules 800131, 800132, 800133
+- Linux: Rules 800151, 800152, 800153, 800154
+- macOS: Rules 800161, 800162, 800163
+
+**USB HID (BadUSB/Rubber Ducky Detection):**
+- Windows: Rules 800140, 800141, 800142
+- Linux: Rules 800155, 800156
+- macOS: Rules 800165, 800166
+
+## MITRE ATT&CK Coverage
+
+- **T1052.001**: Exfiltration Over Physical Medium (USB)
+- **T1200**: Hardware Additions (BadUSB/Rubber Ducky)
+
+## Manager Configuration Required
+
+The Wazuh Manager must have the corresponding Active Response commands and rule bindings configured. See the Wazuh Helm chart `template.config.conf.xml` for the required configuration.
+
+## Manual Verification
+
+After installation, verify scripts are in place:
+
+**Linux:**
+```bash
+ls -la /var/ossec/active-response/bin/disable-usb-storage.sh
+ls -la /var/ossec/active-response/bin/alert-usb-hid.sh
+```
+
+**macOS:**
+```bash
+ls -la /Library/Ossec/active-response/bin/disable-usb-storage-macos.sh
+ls -la /Library/Ossec/active-response/bin/alert-usb-hid.sh
+```
+
+**Windows:**
+```powershell
+Test-Path "C:\Program Files (x86)\ossec-agent\active-response\bin\disable-usb-storage.ps1"
+Test-Path "C:\Program Files (x86)\ossec-agent\active-response\bin\alert-usb-hid.ps1"
+```

--- a/files/active-response/alert-usb-hid.ps1
+++ b/files/active-response/alert-usb-hid.ps1
@@ -1,0 +1,141 @@
+<#
+.SYNOPSIS
+    Wazuh Active Response - USB HID Device Alert and Logging
+
+.DESCRIPTION
+    This script logs and alerts on USB HID device connections (potential BadUSB/Rubber Ducky).
+    It collects detailed device information for forensic analysis and creates
+    audit trail entries. Does NOT disable the device (would disable legitimate keyboards).
+
+.NOTES
+    Rule IDs: 800140, 800141, 800142
+    MITRE ATT&CK: T1200 (Hardware Additions)
+
+    This script focuses on detection and logging rather than prevention,
+    as blocking HID devices would disable legitimate keyboards and mice.
+#>
+
+param (
+    [string]$action,
+    [string]$user,
+    [string]$srcip,
+    [string]$alertid,
+    [string]$ruleid
+)
+
+$logFile = "C:\Program Files (x86)\ossec-agent\active-response\active-responses.log"
+$evidenceDir = "C:\Program Files (x86)\ossec-agent\active-response\usb-evidence"
+$timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+$fileTimestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+
+function Write-Log {
+    param([string]$message)
+    "$timestamp - USB-HID-DLP - $message" | Out-File -Append -FilePath $logFile
+}
+
+try {
+    if ($action -eq "add") {
+        Write-Log "ACTION: USB HID device alert triggered (Rule: $ruleid, Alert: $alertid)"
+
+        # Create evidence directory if it doesn't exist
+        if (-not (Test-Path $evidenceDir)) {
+            New-Item -ItemType Directory -Path $evidenceDir -Force | Out-Null
+        }
+
+        # Collect USB HID device information
+        $hidDevices = Get-WmiObject Win32_PnPEntity | Where-Object {
+            $_.DeviceID -match "HID" -or $_.DeviceID -match "USB\\VID"
+        }
+
+        # Collect keyboard devices specifically
+        $keyboards = Get-WmiObject Win32_Keyboard
+
+        # Save evidence to file
+        $evidenceFile = "$evidenceDir\hid_alert_$fileTimestamp.txt"
+        $evidenceContent = @"
+===========================================
+USB HID DEVICE ALERT - FORENSIC EVIDENCE
+===========================================
+Timestamp: $timestamp
+Alert ID: $alertid
+Rule ID: $ruleid
+Computer: $env:COMPUTERNAME
+User: $env:USERNAME
+
+--- ALL HID DEVICES ---
+$($hidDevices | Format-List DeviceID, Name, Description, Manufacturer, Status | Out-String)
+
+--- KEYBOARD DEVICES ---
+$($keyboards | Format-List DeviceID, Name, Description, Layout | Out-String)
+
+--- USB DEVICE HISTORY (Registry) ---
+"@
+
+        # Get USB device history from registry
+        $usbHistory = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Enum\USB\*\*" -ErrorAction SilentlyContinue |
+            Select-Object PSChildName, DeviceDesc, Mfg, Service
+
+        $evidenceContent += $usbHistory | Format-Table -AutoSize | Out-String
+
+        $evidenceContent | Out-File -FilePath $evidenceFile -Encoding UTF8
+        Write-Log "Evidence saved to: $evidenceFile"
+
+        # Count HID devices for anomaly detection
+        $hidCount = ($hidDevices | Measure-Object).Count
+        $keyboardCount = ($keyboards | Measure-Object).Count
+
+        Write-Log "DEVICE COUNT: $hidCount HID devices, $keyboardCount keyboards detected"
+
+        # Alert on anomaly (more than expected keyboards)
+        if ($keyboardCount -gt 2) {
+            Write-Log "ANOMALY: Multiple keyboards ($keyboardCount) detected - possible BadUSB attack"
+        }
+
+        # Create Windows Event Log entry for SIEM/audit
+        $eventMessage = @"
+USB HID DEVICE SECURITY ALERT
+
+A USB HID device connection was detected that may indicate a BadUSB or Rubber Ducky attack.
+
+Alert Details:
+- Rule ID: $ruleid
+- Alert ID: $alertid
+- Timestamp: $timestamp
+- HID Devices: $hidCount
+- Keyboards: $keyboardCount
+
+RECOMMENDED ACTIONS:
+1. Verify the USB device is authorized
+2. Check for unexpected keyboard devices
+3. Review the evidence file: $evidenceFile
+4. If unauthorized, physically remove the device
+
+Evidence has been collected for forensic analysis.
+"@
+
+        # Create event source if it doesn't exist
+        if (-not [System.Diagnostics.EventLog]::SourceExists("Wazuh-ActiveResponse")) {
+            New-EventLog -LogName Application -Source "Wazuh-ActiveResponse" -ErrorAction SilentlyContinue
+        }
+
+        $eventParams = @{
+            LogName = 'Application'
+            Source = 'Wazuh-ActiveResponse'
+            EventId = 8003
+            EntryType = 'Warning'
+            Message = $eventMessage
+        }
+        Write-EventLog @eventParams -ErrorAction SilentlyContinue
+
+        Write-Log "SUCCESS: USB HID alert processed and evidence collected"
+
+    } elseif ($action -eq "delete") {
+        Write-Log "ACTION: USB HID alert cleared (Rule: $ruleid)"
+    }
+
+    exit 0
+
+} catch {
+    Write-Log "ERROR: Failed to process USB HID alert - $($_.Exception.Message)"
+    exit 1
+}

--- a/files/active-response/alert-usb-hid.sh
+++ b/files/active-response/alert-usb-hid.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+#
+# Wazuh Active Response - USB HID Device Alert (Linux/macOS)
+#
+# Description:
+#   This script logs and alerts on USB HID device connections that may indicate
+#   BadUSB or Rubber Ducky attacks. It collects device information for forensic
+#   analysis without disabling the device (which would disable legitimate keyboards).
+#
+# Usage:
+#   Called automatically by Wazuh Active Response
+#   Manual: ./alert-usb-hid.sh add - - <alert_id> <rule_id>
+#
+# Rule IDs:
+#   Linux: 800155, 800156
+#   macOS: 800165, 800166
+# MITRE ATT&CK: T1200 (Hardware Additions)
+#
+
+LOCAL=$(dirname $0)
+TIMESTAMP=$(date "+%Y-%m-%d %H:%M:%S")
+FILE_TIMESTAMP=$(date "+%Y%m%d_%H%M%S")
+
+# Detect OS and set paths accordingly
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    LOGFILE="/Library/Ossec/logs/active-responses.log"
+    EVIDENCE_DIR="/Library/Ossec/logs/usb-evidence"
+    OS_TYPE="macOS"
+else
+    LOGFILE="/var/ossec/logs/active-responses.log"
+    EVIDENCE_DIR="/var/ossec/logs/usb-evidence"
+    OS_TYPE="Linux"
+fi
+
+# Parse arguments
+ACTION=$1
+USER=$2
+SRCIP=$3
+ALERTID=$4
+RULEID=$5
+
+log_message() {
+    echo "$TIMESTAMP - USB-HID-DLP-$OS_TYPE - $1" >> "$LOGFILE"
+}
+
+# Function to collect HID device evidence on Linux
+collect_linux_evidence() {
+    cat << EOF
+===========================================
+USB HID DEVICE ALERT - FORENSIC EVIDENCE
+===========================================
+Timestamp: $TIMESTAMP
+Alert ID: $ALERTID
+Rule ID: $RULEID
+Computer: $(hostname)
+User: $(whoami)
+OS: $OS_TYPE
+
+--- INPUT DEVICES ---
+$(cat /proc/bus/input/devices 2>/dev/null)
+
+--- USB DEVICES ---
+$(lsusb -v 2>/dev/null | grep -A 5 -i "HID\|keyboard\|mouse" | head -100)
+
+--- HID DEVICES ---
+$(ls -la /dev/hidraw* 2>/dev/null)
+
+--- USB DEVICE TREE ---
+$(lsusb -t 2>/dev/null)
+
+--- DMESG USB EVENTS (last 50) ---
+$(dmesg | grep -i "usb\|hid\|input" | tail -50)
+
+--- XINPUT LIST ---
+$(xinput list 2>/dev/null || echo "X not available")
+EOF
+}
+
+# Function to collect HID device evidence on macOS
+collect_macos_evidence() {
+    cat << EOF
+===========================================
+USB HID DEVICE ALERT - FORENSIC EVIDENCE
+===========================================
+Timestamp: $TIMESTAMP
+Alert ID: $ALERTID
+Rule ID: $RULEID
+Computer: $(hostname)
+User: $(whoami)
+OS: $OS_TYPE
+
+--- USB DEVICES ---
+$(system_profiler SPUSBDataType 2>/dev/null)
+
+--- HID DEVICES ---
+$(ioreg -p IOUSB -l 2>/dev/null | grep -A 10 "HID\|Keyboard")
+
+--- INPUT DEVICES ---
+$(hidutil list 2>/dev/null | head -50)
+
+--- SYSTEM LOG HID EVENTS ---
+$(log show --predicate 'eventMessage contains "HID" or eventMessage contains "keyboard"' --last 30m 2>/dev/null | head -50)
+EOF
+}
+
+case "$ACTION" in
+    add)
+        log_message "ACTION: USB HID device alert triggered (Rule: $RULEID, Alert: $ALERTID)"
+
+        # Create evidence directory
+        mkdir -p "$EVIDENCE_DIR"
+        EVIDENCE_FILE="$EVIDENCE_DIR/hid_alert_$FILE_TIMESTAMP.txt"
+
+        # Collect evidence based on OS
+        if [[ "$OS_TYPE" == "macOS" ]]; then
+            collect_macos_evidence > "$EVIDENCE_FILE"
+        else
+            collect_linux_evidence > "$EVIDENCE_FILE"
+        fi
+
+        log_message "Evidence saved to: $EVIDENCE_FILE"
+
+        # Count HID/keyboard devices for anomaly detection
+        if [[ "$OS_TYPE" == "macOS" ]]; then
+            KEYBOARD_COUNT=$(system_profiler SPUSBDataType 2>/dev/null | grep -ci "keyboard")
+        else
+            KEYBOARD_COUNT=$(cat /proc/bus/input/devices 2>/dev/null | grep -ci "keyboard")
+        fi
+
+        log_message "DEVICE COUNT: $KEYBOARD_COUNT keyboard-type devices detected"
+
+        # Alert if multiple keyboards detected (anomaly)
+        if [ "$KEYBOARD_COUNT" -gt 2 ]; then
+            log_message "ANOMALY: Multiple keyboards ($KEYBOARD_COUNT) detected - possible BadUSB attack!"
+
+            # Send high-priority syslog
+            if [[ "$OS_TYPE" == "macOS" ]]; then
+                /usr/bin/logger -t "Wazuh-DLP" -p local0.alert "CRITICAL: Multiple USB keyboards detected ($KEYBOARD_COUNT) - possible BadUSB attack. Evidence: $EVIDENCE_FILE"
+            else
+                logger -t "Wazuh-DLP" -p auth.alert "CRITICAL: Multiple USB keyboards detected ($KEYBOARD_COUNT) - possible BadUSB attack. Evidence: $EVIDENCE_FILE"
+            fi
+        else
+            # Standard syslog entry
+            if [[ "$OS_TYPE" == "macOS" ]]; then
+                /usr/bin/logger -t "Wazuh-DLP" "USB HID device alert. Rule: $RULEID, Alert: $ALERTID. Evidence: $EVIDENCE_FILE"
+            else
+                logger -t "Wazuh-DLP" -p auth.warning "USB HID device alert. Rule: $RULEID, Alert: $ALERTID. Evidence: $EVIDENCE_FILE"
+            fi
+        fi
+
+        # macOS notification (optional)
+        if [[ "$OS_TYPE" == "macOS" ]] && command -v osascript &> /dev/null; then
+            osascript -e 'display notification "USB HID device detected - please verify authorized" with title "Wazuh Security Alert" subtitle "USB HID Detection"' 2>/dev/null
+        fi
+
+        # Linux desktop notification (optional)
+        if [[ "$OS_TYPE" == "Linux" ]] && command -v notify-send &> /dev/null; then
+            notify-send -u critical "Wazuh Security Alert" "USB HID device detected - please verify authorized" 2>/dev/null
+        fi
+
+        log_message "SUCCESS: USB HID alert processed and evidence collected"
+        ;;
+
+    delete)
+        log_message "ACTION: USB HID alert cleared (Rule: $RULEID)"
+        ;;
+
+    *)
+        log_message "ERROR: Unknown action: $ACTION"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/files/active-response/disable-usb-storage-macos.sh
+++ b/files/active-response/disable-usb-storage-macos.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+#
+# Wazuh Active Response - Disable USB Mass Storage (macOS)
+#
+# Description:
+#   This script disables USB mass storage devices on macOS when triggered by
+#   Wazuh alert rules. It uses diskutil to unmount and eject USB devices.
+#
+# Note: macOS doesn't support kernel module unloading like Linux.
+#   This script focuses on ejecting connected devices and logging.
+#   For full USB blocking on macOS, MDM solutions are recommended.
+#
+# Usage:
+#   Called automatically by Wazuh Active Response
+#   Manual: ./disable-usb-storage-macos.sh add - - <alert_id> <rule_id>
+#
+# Rule IDs: 800161, 800162, 800163, 800170
+# MITRE ATT&CK: T1052.001 (Exfiltration Over Physical Medium)
+#
+
+LOCAL=$(dirname $0)
+LOGFILE="/Library/Ossec/logs/active-responses.log"
+EVIDENCE_DIR="/Library/Ossec/logs/usb-evidence"
+TIMESTAMP=$(date "+%Y-%m-%d %H:%M:%S")
+FILE_TIMESTAMP=$(date "+%Y%m%d_%H%M%S")
+
+# Parse arguments
+ACTION=$1
+USER=$2
+SRCIP=$3
+ALERTID=$4
+RULEID=$5
+
+log_message() {
+    echo "$TIMESTAMP - USB-DLP-macOS - $1" >> "$LOGFILE"
+}
+
+# Function to get external USB disks
+get_external_disks() {
+    diskutil list external 2>/dev/null | grep -E "^/dev/disk" | awk '{print $1}'
+}
+
+# Function to collect evidence
+collect_evidence() {
+    mkdir -p "$EVIDENCE_DIR"
+    EVIDENCE_FILE="$EVIDENCE_DIR/usb_alert_$FILE_TIMESTAMP.txt"
+
+    cat > "$EVIDENCE_FILE" << EOF
+===========================================
+USB STORAGE ALERT - FORENSIC EVIDENCE
+===========================================
+Timestamp: $TIMESTAMP
+Alert ID: $ALERTID
+Rule ID: $RULEID
+Computer: $(hostname)
+User: $(whoami)
+
+--- EXTERNAL DISKS ---
+$(diskutil list external 2>/dev/null)
+
+--- USB DEVICES ---
+$(system_profiler SPUSBDataType 2>/dev/null)
+
+--- MOUNTED VOLUMES ---
+$(mount | grep -v "^/dev/disk0\|^/dev/disk1")
+
+--- DISK ARBITRATION HISTORY ---
+$(log show --predicate 'subsystem == "com.apple.diskarbitrationd"' --last 1h 2>/dev/null | head -50)
+EOF
+
+    log_message "Evidence saved to: $EVIDENCE_FILE"
+    echo "$EVIDENCE_FILE"
+}
+
+case "$ACTION" in
+    add)
+        log_message "ACTION: Processing USB Mass Storage alert (Rule: $RULEID, Alert: $ALERTID)"
+
+        # Collect forensic evidence first
+        EVIDENCE_FILE=$(collect_evidence)
+
+        # Get list of external disks
+        EXTERNAL_DISKS=$(get_external_disks)
+
+        if [ -n "$EXTERNAL_DISKS" ]; then
+            for disk in $EXTERNAL_DISKS; do
+                log_message "Processing external disk: $disk"
+
+                # Get disk info
+                DISK_INFO=$(diskutil info "$disk" 2>/dev/null | grep -E "Device / Media Name|Volume Name|Removable Media")
+                log_message "Disk info: $DISK_INFO"
+
+                # Unmount all volumes on this disk
+                log_message "Unmounting all volumes on $disk"
+                diskutil unmountDisk "$disk" 2>/dev/null
+
+                if [ $? -eq 0 ]; then
+                    log_message "SUCCESS: Unmounted all volumes on $disk"
+
+                    # Attempt to eject the disk
+                    log_message "Ejecting $disk"
+                    diskutil eject "$disk" 2>/dev/null
+
+                    if [ $? -eq 0 ]; then
+                        log_message "SUCCESS: Ejected $disk"
+                    else
+                        log_message "WARNING: Could not eject $disk"
+                    fi
+                else
+                    log_message "WARNING: Could not unmount $disk - device may be in use"
+                fi
+            done
+        else
+            log_message "No external USB disks currently connected"
+        fi
+
+        # Create system log entry for audit
+        /usr/bin/logger -t "Wazuh-DLP" "USB Mass Storage alert processed. Rule: $RULEID, Alert: $ALERTID. Evidence: $EVIDENCE_FILE"
+
+        # Send notification to user (optional - requires terminal-notifier or osascript)
+        if command -v osascript &> /dev/null; then
+            osascript -e 'display notification "USB storage device detected and processed by security policy" with title "Wazuh Security Alert" subtitle "USB DLP"' 2>/dev/null
+        fi
+
+        log_message "SUCCESS: USB Mass Storage alert processed"
+        ;;
+
+    delete)
+        log_message "ACTION: USB alert cleared (Rule: $RULEID)"
+        /usr/bin/logger -t "Wazuh-DLP" "USB Mass Storage alert cleared. Rule: $RULEID"
+        ;;
+
+    *)
+        log_message "ERROR: Unknown action: $ACTION"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/files/active-response/disable-usb-storage.ps1
+++ b/files/active-response/disable-usb-storage.ps1
@@ -1,0 +1,95 @@
+<#
+.SYNOPSIS
+    Wazuh Active Response - Disable USB Mass Storage
+
+.DESCRIPTION
+    This script disables USB mass storage devices when triggered by Wazuh
+    alert rules (800131, 800132, 800133). It modifies registry settings
+    to prevent USB storage devices from functioning.
+
+.NOTES
+    Rule IDs: 800131, 800132, 800133
+    MITRE ATT&CK: T1052.001 (Exfiltration Over Physical Medium)
+
+    To restore USB access, run: Set-ItemProperty -Path $usbStorPath -Name "Start" -Value 3
+#>
+
+param (
+    [string]$action,
+    [string]$user,
+    [string]$srcip,
+    [string]$alertid,
+    [string]$ruleid
+)
+
+$logFile = "C:\Program Files (x86)\ossec-agent\active-response\active-responses.log"
+$timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+
+function Write-Log {
+    param([string]$message)
+    "$timestamp - USB-DLP - $message" | Out-File -Append -FilePath $logFile
+}
+
+# Registry path for USB storage
+$usbStorPath = "HKLM:\SYSTEM\CurrentControlSet\Services\USBSTOR"
+
+try {
+    if ($action -eq "add") {
+        Write-Log "ACTION: Disabling USB Mass Storage (Rule: $ruleid, Alert: $alertid)"
+
+        # Disable USB Storage by setting Start value to 4 (Disabled)
+        Set-ItemProperty -Path $usbStorPath -Name "Start" -Value 4 -ErrorAction Stop
+
+        # Log the action
+        Write-Log "SUCCESS: USB Mass Storage disabled via registry"
+
+        # Get list of current USB storage devices
+        $usbDevices = Get-WmiObject Win32_DiskDrive | Where-Object { $_.InterfaceType -eq "USB" }
+
+        foreach ($device in $usbDevices) {
+            Write-Log "WARNING: USB Storage device present: $($device.Model) - $($device.DeviceID)"
+
+            # Attempt to eject the device (optional - requires additional tools)
+            # Note: Full ejection requires third-party tools or device-specific commands
+        }
+
+        # Create Windows Event Log entry for audit trail
+        $eventParams = @{
+            LogName = 'Application'
+            Source = 'Wazuh-ActiveResponse'
+            EventId = 8001
+            EntryType = 'Warning'
+            Message = "USB Mass Storage DISABLED by Wazuh DLP. Rule: $ruleid, Alert: $alertid"
+        }
+
+        # Create event source if it doesn't exist
+        if (-not [System.Diagnostics.EventLog]::SourceExists("Wazuh-ActiveResponse")) {
+            New-EventLog -LogName Application -Source "Wazuh-ActiveResponse" -ErrorAction SilentlyContinue
+        }
+        Write-EventLog @eventParams -ErrorAction SilentlyContinue
+
+    } elseif ($action -eq "delete") {
+        Write-Log "ACTION: Re-enabling USB Mass Storage (Rule: $ruleid)"
+
+        # Re-enable USB Storage by setting Start value to 3 (Manual/Enabled)
+        Set-ItemProperty -Path $usbStorPath -Name "Start" -Value 3 -ErrorAction Stop
+
+        Write-Log "SUCCESS: USB Mass Storage re-enabled via registry"
+
+        # Create Windows Event Log entry
+        $eventParams = @{
+            LogName = 'Application'
+            Source = 'Wazuh-ActiveResponse'
+            EventId = 8002
+            EntryType = 'Information'
+            Message = "USB Mass Storage RE-ENABLED by Wazuh DLP. Rule: $ruleid"
+        }
+        Write-EventLog @eventParams -ErrorAction SilentlyContinue
+    }
+
+    exit 0
+
+} catch {
+    Write-Log "ERROR: Failed to modify USB settings - $($_.Exception.Message)"
+    exit 1
+}

--- a/files/active-response/disable-usb-storage.sh
+++ b/files/active-response/disable-usb-storage.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+#
+# Wazuh Active Response - Disable USB Mass Storage (Linux)
+#
+# Description:
+#   This script disables USB mass storage devices when triggered by Wazuh
+#   alert rules (800151, 800152, 800153, 800154). It can either:
+#   - Unload the usb-storage kernel module (prevents new devices)
+#   - Unmount and eject connected USB storage devices
+#
+# Usage:
+#   Called automatically by Wazuh Active Response
+#   Manual: ./disable-usb-storage.sh add - - <alert_id> <rule_id>
+#
+# Rule IDs: 800151, 800152, 800153, 800154, 800170
+# MITRE ATT&CK: T1052.001 (Exfiltration Over Physical Medium)
+#
+
+LOCAL=$(dirname $0)
+LOGFILE="/var/ossec/logs/active-responses.log"
+TIMESTAMP=$(date "+%Y-%m-%d %H:%M:%S")
+
+# Parse arguments
+ACTION=$1
+USER=$2
+SRCIP=$3
+ALERTID=$4
+RULEID=$5
+
+log_message() {
+    echo "$TIMESTAMP - USB-DLP-Linux - $1" >> $LOGFILE
+}
+
+# Function to get list of USB storage devices
+get_usb_storage_devices() {
+    lsblk -o NAME,TRAN,MOUNTPOINT -n 2>/dev/null | grep "usb" | awk '{print $1}'
+}
+
+# Function to get USB mount points
+get_usb_mounts() {
+    mount | grep -E "/dev/sd[a-z]+[0-9]+" | grep -v "$(mount | grep -E 'sda|nvme')" | awk '{print $3}'
+}
+
+case "$ACTION" in
+    add)
+        log_message "ACTION: Disabling USB Mass Storage (Rule: $RULEID, Alert: $ALERTID)"
+
+        # Method 1: Unmount any mounted USB storage
+        USB_MOUNTS=$(get_usb_mounts)
+        if [ -n "$USB_MOUNTS" ]; then
+            for mount_point in $USB_MOUNTS; do
+                log_message "Unmounting USB device at: $mount_point"
+                umount "$mount_point" 2>/dev/null
+                if [ $? -eq 0 ]; then
+                    log_message "SUCCESS: Unmounted $mount_point"
+                else
+                    log_message "WARNING: Failed to unmount $mount_point - device may be in use"
+                fi
+            done
+        fi
+
+        # Method 2: Disable usb-storage kernel module (prevents new USB storage devices)
+        # Check if module is loaded
+        if lsmod | grep -q "usb_storage"; then
+            log_message "Attempting to unload usb-storage kernel module"
+
+            # Remove the module (may fail if devices are mounted)
+            modprobe -r usb_storage 2>/dev/null
+            if [ $? -eq 0 ]; then
+                log_message "SUCCESS: usb-storage module unloaded"
+            else
+                log_message "WARNING: Could not unload usb-storage module - devices may be in use"
+            fi
+        fi
+
+        # Method 3: Blacklist usb-storage module to prevent loading on next device connect
+        if [ ! -f /etc/modprobe.d/wazuh-usb-block.conf ]; then
+            echo "# Wazuh DLP - USB Storage blocked" > /etc/modprobe.d/wazuh-usb-block.conf
+            echo "blacklist usb-storage" >> /etc/modprobe.d/wazuh-usb-block.conf
+            echo "install usb-storage /bin/false" >> /etc/modprobe.d/wazuh-usb-block.conf
+            log_message "SUCCESS: USB storage module blacklisted"
+        fi
+
+        # Method 4: Use udev rules to prevent USB storage (more persistent)
+        UDEV_RULE="/etc/udev/rules.d/99-wazuh-usb-block.rules"
+        if [ ! -f "$UDEV_RULE" ]; then
+            cat > "$UDEV_RULE" << 'EOF'
+# Wazuh DLP - Block USB Storage Devices
+# To re-enable, remove this file and run: udevadm control --reload-rules
+SUBSYSTEM=="usb", DRIVER=="usb-storage", ACTION=="add", RUN+="/bin/sh -c 'echo 0 > /sys$DEVPATH/authorized'"
+SUBSYSTEM=="block", ATTRS{removable}=="1", ACTION=="add", RUN+="/bin/sh -c 'echo 0 > /sys$DEVPATH/device/authorized'"
+EOF
+            udevadm control --reload-rules
+            log_message "SUCCESS: udev rules installed to block USB storage"
+        fi
+
+        # Log current USB devices for audit
+        log_message "Current USB devices: $(lsusb 2>/dev/null | wc -l) devices"
+
+        # Create syslog entry for SIEM
+        logger -t "Wazuh-DLP" -p auth.warning "USB Mass Storage DISABLED by Wazuh. Rule: $RULEID, Alert: $ALERTID"
+
+        log_message "SUCCESS: USB Mass Storage blocking enabled"
+        ;;
+
+    delete)
+        log_message "ACTION: Re-enabling USB Mass Storage (Rule: $RULEID)"
+
+        # Remove blacklist
+        if [ -f /etc/modprobe.d/wazuh-usb-block.conf ]; then
+            rm -f /etc/modprobe.d/wazuh-usb-block.conf
+            log_message "Removed usb-storage blacklist"
+        fi
+
+        # Remove udev rules
+        if [ -f /etc/udev/rules.d/99-wazuh-usb-block.rules ]; then
+            rm -f /etc/udev/rules.d/99-wazuh-usb-block.rules
+            udevadm control --reload-rules
+            log_message "Removed udev blocking rules"
+        fi
+
+        # Reload usb-storage module
+        modprobe usb_storage 2>/dev/null
+        if [ $? -eq 0 ]; then
+            log_message "SUCCESS: usb-storage module reloaded"
+        fi
+
+        logger -t "Wazuh-DLP" -p auth.info "USB Mass Storage RE-ENABLED by Wazuh. Rule: $RULEID"
+        log_message "SUCCESS: USB Mass Storage re-enabled"
+        ;;
+
+    *)
+        log_message "ERROR: Unknown action: $ACTION"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/scripts/setup-agent.ps1
+++ b/scripts/setup-agent.ps1
@@ -240,6 +240,38 @@ function Install-AgentStatus {
     }
 }
 
+# Step 7: Install USB DLP Active Response scripts
+function Install-USBDLPScripts {
+    $AR_BIN_DIR = Join-Path -Path $OSSEC_PATH -ChildPath "active-response\bin"
+    $USB_DLP_BASE_URL = "https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent/refs/tags/v$WAZUH_AGENT_REPO_VERSION/files/active-response"
+
+    try {
+        InfoMessage "Installing USB DLP Active Response scripts..."
+
+        # Create directory if it doesn't exist
+        if (!(Test-Path -Path $AR_BIN_DIR)) {
+            New-Item -ItemType Directory -Path $AR_BIN_DIR -Force | Out-Null
+        }
+
+        # Download USB storage blocking script
+        $USBStorageScript = Join-Path -Path $AR_BIN_DIR -ChildPath "disable-usb-storage.ps1"
+        InfoMessage "Downloading disable-usb-storage.ps1..."
+        Invoke-WebRequest -Uri "$USB_DLP_BASE_URL/disable-usb-storage.ps1" -OutFile $USBStorageScript -ErrorAction Stop
+
+        # Download USB HID alerting script
+        $USBHIDScript = Join-Path -Path $AR_BIN_DIR -ChildPath "alert-usb-hid.ps1"
+        InfoMessage "Downloading alert-usb-hid.ps1..."
+        Invoke-WebRequest -Uri "$USB_DLP_BASE_URL/alert-usb-hid.ps1" -OutFile $USBHIDScript -ErrorAction Stop
+
+        SuccessMessage "USB DLP Active Response scripts installed successfully."
+        InfoMessage "  - $USBStorageScript"
+        InfoMessage "  - $USBHIDScript"
+    }
+    catch {
+        ErrorMessage "Error during USB DLP scripts installation: $($_.Exception.Message)"
+    }
+}
+
 function DownloadVersionFile {
     InfoMessage "Downloading version file..."
     if (!(Test-Path -Path $OSSEC_PATH)) {
@@ -331,6 +363,9 @@ try {
     else {
         WarningMessage "Neither Snort nor Suricata selected for installation. Skipping."
     }
+
+    SectionSeparator "Installing USB DLP Scripts"
+    Install-USBDLPScripts
 
     SectionSeparator "Downloading Version File"
     DownloadVersionFile


### PR DESCRIPTION
## Summary

- Add cross-platform USB Data Loss Prevention (DLP) Active Response scripts
- Scripts are automatically deployed during agent setup via `setup-agent.sh` and `setup-agent.ps1`
- Addresses ISO 27001 requirements for data exfiltration prevention

## Scripts Added

| Script | Platform | Purpose |
|--------|----------|---------|
| `disable-usb-storage.sh` | Linux | Block USB mass storage via kernel module |
| `disable-usb-storage-macos.sh` | macOS | Eject USB devices via diskutil |
| `disable-usb-storage.ps1` | Windows | Block USB storage via registry |
| `alert-usb-hid.sh` | Linux/macOS | BadUSB/Rubber Ducky detection |
| `alert-usb-hid.ps1` | Windows | BadUSB/Rubber Ducky detection |

## MITRE ATT&CK Coverage

- **T1052.001**: Exfiltration Over Physical Medium (USB)
- **T1200**: Hardware Additions (BadUSB/Rubber Ducky)

## Installation

Scripts are automatically installed to:
- Linux: `/var/ossec/active-response/bin/`
- macOS: `/Library/Ossec/active-response/bin/`
- Windows: `C:\Program Files (x86)\ossec-agent\active-response\bin\`

## Test Plan

- [ ] Test Linux agent installation with USB DLP scripts
- [ ] Test macOS agent installation with USB DLP scripts
- [ ] Test Windows agent installation with USB DLP scripts
- [ ] Verify script permissions (750 on Linux/macOS)
- [ ] Verify scripts are triggered by Wazuh Manager rules