### PR TITLE
chore: bump framework version to 1.8.1 in versions.json

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -3,7 +3,7 @@
   "name": "wazuh-agent",
   "description": "Wazuh Agent deployment framework version compatibility matrix",
   "framework": {
-    "version": "1.8.0",
+    "version": "1.8.1",
     "release_date": "2026-02-26",
     "min_supported": "1.4.0",
     "prerelease_version": "1.9.0-rc.4"


### PR DESCRIPTION
Updates the framework version from 1.8.0 to 1.8.1 to match our recent release.